### PR TITLE
 ConditionLogモデルとマイグレーションを追加

### DIFF
--- a/refresh_meter_app/app/models/condition_log.rb
+++ b/refresh_meter_app/app/models/condition_log.rb
@@ -1,0 +1,28 @@
+class ConditionLog < ApplicationRecord
+    enum :work_difficulty, {
+        light: 0,
+        normal: 1,
+        hard: 2,
+        very_hard: 3
+    }
+
+    enum :mood, {
+        no_motivation: 0,
+        depressed: 1,
+        normal: 2,
+        energetic: 3
+    }
+
+    validates :fatigue, presence: true, inclusion: { in: 0..100 }
+    validates :stress, presence: true, inclusion: { in: 0..100 }
+    validates :sleep_hours, presence: true, numericality: {greater_than_or_equal_to: 0}
+    validates :daytime_outings, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0 }
+    validates :night_outings, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0 }
+    validates :work_difficulty, presence: true
+    validates :mood, presence: true
+    validates :recorded_at, presence: true
+
+    def effective_days
+        daytime_outings * 1.0 + night_outings *0.5 
+    end
+end

--- a/refresh_meter_app/db/migrate/20260504103322_create_condition_logs.rb
+++ b/refresh_meter_app/db/migrate/20260504103322_create_condition_logs.rb
@@ -1,0 +1,19 @@
+class CreateConditionLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :condition_logs do |t|
+      t.integer :fatigue, null: false
+      t.integer :stress, null: false
+      t.decimal :sleep_hours, null: false, precision: 4, scale: 1
+      t.integer :daytime_outings, null: false, default: 0
+      t.integer :night_outings, null: false, default: 0
+      t.integer :work_difficulty, null: false
+      t.string :mood, null: false
+      t.date :last_sauna_date
+      t.date :last_movie_date
+      t.date :last_karaoke_date
+      t.datetime :recorded_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/refresh_meter_app/db/schema.rb
+++ b/refresh_meter_app/db/schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_103322) do
+  create_table "condition_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "daytime_outings", default: 0, null: false
+    t.integer "fatigue", null: false
+    t.date "last_karaoke_date"
+    t.date "last_movie_date"
+    t.date "last_sauna_date"
+    t.string "mood", null: false
+    t.integer "night_outings", default: 0, null: false
+    t.datetime "recorded_at", null: false
+    t.decimal "sleep_hours", precision: 4, scale: 1, null: false
+    t.integer "stress", null: false
+    t.datetime "updated_at", null: false
+    t.integer "work_difficulty", null: false
+  end
+end

--- a/refresh_meter_app/test/fixtures/condition_logs.yml
+++ b/refresh_meter_app/test/fixtures/condition_logs.yml
@@ -1,0 +1,25 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  fatigue: 1
+  stress: 1
+  sleep_hours: 9.99
+  daytime_outings: 1
+  work_difficulty: 1
+  mood: MyString
+  last_sauna_data: 2026-05-04
+  last_move_date: 2026-05-04
+  last_karaoke_date: 2026-05-04
+  recorded_at: 2026-05-04 10:33:22
+
+two:
+  fatigue: 1
+  stress: 1
+  sleep_hours: 9.99
+  daytime_outings: 1
+  work_difficulty: 1
+  mood: MyString
+  last_sauna_data: 2026-05-04
+  last_move_date: 2026-05-04
+  last_karaoke_date: 2026-05-04
+  recorded_at: 2026-05-04 10:33:22

--- a/refresh_meter_app/test/models/condition_log_test.rb
+++ b/refresh_meter_app/test/models/condition_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ConditionLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
状態入力機能の一部として、ConditionLog(ユーザーの体調状態や心理状態を管理するテーブル)モデルとマイグレーションを追加しました

## 背景
Refresh-Meterはユーザーの体調、心理状態をもとにアクティビティの推奨どを算出するアプリ。
状態入力機能の実装として、まずデータの受け皿となるConditionLogモデルとテーブルを整備しました。

## 変更内容
- condition_logsテーブルのマイグレーションを追加

## 詳細と補足
- 疲労度、ストレス、睡眠時間、外出日数、作業難易度、気分、アクティビティ最終実施日
- 外出日数は日中・夜で別カラムで管理(daytime_outings / night_outings)
- 外出スコア換算メソッド(effective_days)を追加し、外出スコアとしてのフィールドを準備